### PR TITLE
adds a new 'nullable' validation option which allows null values as validated data

### DIFF
--- a/src/Validator.php
+++ b/src/Validator.php
@@ -31,6 +31,7 @@ class Validator
         'textKey',
         'date',
         'dateTime',
+        'nullable',
         'custom'
     ];
 
@@ -126,7 +127,10 @@ class Validator
                 if (is_string($value) && (!isset($ruleProperties['trim']) || $ruleProperties['trim'] === true)) {
                     $value = trim($value);
                 }
-            // Don't validate empty values that are not set and not required
+                // allow a nullable value to be added as validated data
+            } elseif (!empty($ruleProperties['nullable']) && array_key_exists($fieldName, $data)) {
+                $value = null;
+                // Don't validate empty values that are not set and not required
             } elseif (empty($ruleProperties['required']) && empty($ruleProperties['nonEmpty'])) {
                 continue;
             } else {
@@ -326,6 +330,8 @@ class Validator
 
                     $errorMsg = $ruleContents($value);
 
+                    break;
+                case 'nullable':
                     break;
                 default:
                     throw new \InvalidArgumentException("Unknown validation rule[{$rule}]");

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -16,7 +16,6 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         $rules = [];
         $rules['someField']['minLength'] = 5;
         $rules['nonRequiredField'] = [];
-        $rules['nullableField']['nullable'] = true;
 
         $this->validator = new Validator($rules);
     }
@@ -340,21 +339,41 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('required', $this->validator->getValidRuleProperties());
     }
 
-    public function testValidateNullableValueDoesNotReturnErrorMsg()
+    /**
+     * @dataProvider provideNullableTestValues
+     */
+    public function testValidateNullableValueDoesNotReturnErrorMsg($value)
     {
-        $errorMsgs = $this->validator->validateValue(null, ['nullable' => true]);
+        $errorMsgs = $this->validator->validateValue($value, ['nullable' => true]);
         $this->assertEmpty($errorMsgs);
     }
 
-    public function testValidateNullableData()
+    public function provideNullableTestValues()
     {
-        $data = ['nullableField' => null];
+        return [
+            [null],
+            ['0'],
+            [''],
+            ['another string']
+        ];
+    }
+
+    /**
+     * @dataProvider provideNullableTestValues
+     */
+    public function testValidateNullableData($value)
+    {
+        $newFieldRules = [
+            'nullableField' => ['nullable' => true]
+        ];
+        $this->validator->addFieldsRuleProperties($newFieldRules);
+        $data = ['nullableField' => $value];
         $errorMsgs = $this->validator->validate($data);
         $this->assertEmpty($errorMsgs);
 
         $validatedData = $this->validator->getValidatedData();
 
         $this->assertArrayHasKey('nullableField', $validatedData);
-        $this->assertNull($validatedData['nullableField']);
+        $this->assertSame($value, $validatedData['nullableField']);
     }
 }

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -16,6 +16,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         $rules = [];
         $rules['someField']['minLength'] = 5;
         $rules['nonRequiredField'] = [];
+        $rules['nullableField']['nullable'] = true;
 
         $this->validator = new Validator($rules);
     }
@@ -337,5 +338,23 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
     public function testGetValidRuleProperties()
     {
         $this->assertContains('required', $this->validator->getValidRuleProperties());
+    }
+
+    public function testValidateNullableValueDoesNotReturnErrorMsg()
+    {
+        $errorMsgs = $this->validator->validateValue(null, ['nullable' => true]);
+        $this->assertEmpty($errorMsgs);
+    }
+
+    public function testValidateNullableData()
+    {
+        $data = ['nullableField' => null];
+        $errorMsgs = $this->validator->validate($data);
+        $this->assertEmpty($errorMsgs);
+
+        $validatedData = $this->validator->getValidatedData();
+
+        $this->assertArrayHasKey('nullableField', $validatedData);
+        $this->assertNull($validatedData['nullableField']);
     }
 }


### PR DESCRIPTION
This PR overcomes the limitation to explicitly validate and accept an optional data key set to `null`. At the moment any value without a validation rule `required` or `nonEmpty` set to `null` will not be set in the internal `validatedData` array.

The PR adds a new virtual `nullable` configuration option to the Validator class allowing a `null` value to be set in the internal `validatedData` array.