### PR TITLE
cast value as string before passing it to mb_strlen

### DIFF
--- a/src/Validator.php
+++ b/src/Validator.php
@@ -259,7 +259,7 @@ class Validator
                         throw new \InvalidArgumentException("Invalid length validation rule[{$ruleContents}]");
                     }
 
-                    if ($isValueSet && mb_strlen($value) !== $ruleContents) {
+                    if ($isValueSet && mb_strlen((string) $value) !== $ruleContents) {
                         $errorMsg = $this->translator->trans(
                             'errorFieldMustBeXLength',
                             ['%field%' => $fieldName, '%numberOf%' => $ruleContents]


### PR DESCRIPTION
`$value` is passed as mixed variable to the `Validator::validateValue` function and needs to be casted as string before passing it to functions which expect a string.